### PR TITLE
Fix template to handle undefined rule content

### DIFF
--- a/templates/go-audit.yaml.erb
+++ b/templates/go-audit.yaml.erb
@@ -112,7 +112,7 @@ if @data['rules'] then
         if line != :undef then
           line.chomp!
         else
-          line = '# UNDEFINED'
+          line = ''
         end
         "- \"#{line}\""
       }


### PR DESCRIPTION
In a previous commit we added handling for undefined content.  Unfortunatley
go-audit won't start with comment code in the rules, so we must simply return
an empty string.  This still makes it much easier to debug that a hard failure
as we previously had.