### PR TITLE
Allow syslog address to be a string

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,7 +98,7 @@ class goaudit (
       )
     )
   }
-  validate_absolute_path($output_syslog_address)
+  validate_string($output_syslog_address)
   validate_integer($output_syslog_priority)
   validate_string($output_syslog_tag)
 


### PR DESCRIPTION
The syslog address value can be either a path, an IP address, domain, etc.
For example it could be any of the following:

- 192.0.2.1:80
- golang.org:http
- \[2001:db8::1]:http
- \[fe80::1%lo0]:80
- :80

We therefore only validate it as a string.