### PR TITLE
Automatically append the "enable" rule to the ruleset

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -43,6 +43,15 @@ class goaudit::config {
     },
   }
 
+  if ($::goaudit::auto_enable_rule != 'none') {
+    datacat_fragment { 'go-audit audit enable rule' :
+      target          => $::goaudit::config_file,
+      data            => {
+        'enable_rule' => $::goaudit::auto_enable_rule,
+      }
+    }
+  }
+
   datacat { $::goaudit::config_file :
     ensure   => 'file',
     owner    => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,6 +69,7 @@ class goaudit (
   $output_file_user         = $goaudit::params::output_file_user,
   $output_file_group        = $goaudit::params::output_file_group,
   $log_flags                = $goaudit::params::log_flags,
+  $auto_enable_rule         = $goaudit::params::auto_enable_rule,
 ) inherits goaudit::params {
 
   validate_string($package_name)
@@ -110,6 +111,17 @@ class goaudit (
   validate_string($output_file_group)
 
   validate_integer($log_flags)
+
+  $valid_auto_enable_rule_values = [
+    'none', 'disable', 'enable', 'lock'
+  ]
+  if ! ($auto_enable_rule in $valid_auto_enable_rule_values) {
+    fail(
+      sprintf('auto_enable_rule must be one of %s',
+        join($valid_auto_enable_rule_values, ', ')
+      )
+    )
+  }
 
   anchor { 'goaudit::begin': } ->
   class { '::goaudit::install': } ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,6 +29,8 @@ class goaudit::params {
 
   $log_flags = 0
 
+  $auto_enable_rule = 'enable'
+
   case $::osfamily {
     'Debian': {
       $package_name = 'go-audit'

--- a/templates/go-audit.yaml.erb
+++ b/templates/go-audit.yaml.erb
@@ -119,6 +119,22 @@ if @data['rules'] then
     )
   end
 
+  if @data['enable_rule'] then
+    case @data['enable_rule']
+    when 'disable'
+      enable_flag = 0
+    when 'enable'
+      enable_flag = 1
+    when 'lock'
+      enable_flag = 2
+    end
+
+    output_lines.push([
+      "# Auto-added by goaudit::auto_enable_rule",
+      "- -e #{enable_flag}",
+    ])
+  end
+
   output_lines.flatten!
   # Go back over our output buffer and indent by two spaces
   output_lines.map! { |line| "  #{line}" }


### PR DESCRIPTION
We expect that 9 times out of 10 the user will want to enable the audit subsystem with an `-e 1` rule at the end of the ruleset. Add a class parameter to the base class to control this. The enable action can be overridden to `-e 0` (disable), `-e 2` (lock), or removed altogether, so the module only configures rules as given explicitly via `goaudit::rule` resources.