### PR TITLE
Support the future parser - make 'order' default to a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ class { '::goaudit': }
 
 ```
 goaudit::rule { 'TLS private key access' :
-  order   => 50,
+  order   => '50',
   comment => 'Reads, writes and attribute changes on TLS private keys',
   content => [
     '-w /etc/ssl/private/foo.key -p rwa -k tls-key-access',
@@ -303,9 +303,9 @@ to the kernel by Go-Audit on startup via a sequence of calls to the `auditctl` c
 An ordering hint. `goaudit::rule` resources will be sorted by their order before being applied to
 the configuration.
 
-Valid values: integers
+Valid values: integers formatted as strings
 
-Default value: `10`
+Default value: `'10'`
 
 ##### `comment`
 
@@ -326,9 +326,9 @@ Adds a filter to the Go-Audit configuration.
 An ordering hint. `goaudit::filter` resources will be sorted by their order before being applied to
 the configuration.
 
-Valid values: integers
+Valid values: integers formatted as strings
 
-Default value: `10`
+Default value: `'10'`
 
 ##### `comment`
 

--- a/manifests/filter.pp
+++ b/manifests/filter.pp
@@ -3,7 +3,7 @@ define goaudit::filter (
   $syscall,
   $message_type,
   $regex,
-  $order   = 10,
+  $order   = '10',
   $comment = undef,
 ) {
 

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -1,7 +1,7 @@
 # See README.md
 define goaudit::rule (
   $content,
-  $order   = 10,
+  $order   = '10',
   $comment = undef,
 ) {
 

--- a/spec/defines/filter_spec.rb
+++ b/spec/defines/filter_spec.rb
@@ -10,7 +10,7 @@ describe 'goaudit::filter' do
 
   describe 'complete example' do
     let (:params) {{
-      :order        => 9,
+      :order        => '9',
       :comment      => 'rspec comment',
       :syscall      => 1234,
       :message_type => 4321,
@@ -20,7 +20,7 @@ describe 'goaudit::filter' do
     it {
       is_expected.to contain_datacat_fragment('go-audit filter example').with({
         :target => '/etc/go-audit.yaml',
-        :order  => 9,
+        :order  => '9',
         :data   => {
           'filters' => [
             {

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -16,7 +16,7 @@ describe 'goaudit::rule' do
     it {
       is_expected.to contain_datacat_fragment('go-audit rule example').with({
         :target => '/etc/go-audit.yaml',
-        :order  => 10,
+        :order  => '10',
         :data   => {
           'rules' => [
             {
@@ -37,7 +37,7 @@ describe 'goaudit::rule' do
     it {
       is_expected.to contain_datacat_fragment('go-audit rule example').with({
         :target => '/etc/go-audit.yaml',
-        :order  => 10,
+        :order  => '10',
         :data   => {
           'rules' => [
             {
@@ -59,7 +59,7 @@ describe 'goaudit::rule' do
     it {
       is_expected.to contain_datacat_fragment('go-audit rule example').with({
         :target => '/etc/go-audit.yaml',
-        :order  => 10,
+        :order  => '10',
         :data   => {
           'rules' => [
             {


### PR DESCRIPTION
datacat's 'order' parameter is actually a string (defaulting to "50") and
having a default which is an integer causes the following error on Puppet 3.8.7
with the future parser enabled.

  Error: /Stage[main]/Goaudit::Config/Datacat[/etc/go-audit.yaml]/Datacat_collector[/etc/go-audit.yaml]: Could not evaluate: comparison of Puppet::Type::Datacat_fragment with Puppet::Type::Datacat_fragment failed

Change the default for goaudit::filter and goaudit::rule's 'order' parameter to
be "10"